### PR TITLE
Use cache instead of db

### DIFF
--- a/maintenance-filter-api/src/main/java/org/ccci/maintenance/MaintenanceWindow.java
+++ b/maintenance-filter-api/src/main/java/org/ccci/maintenance/MaintenanceWindow.java
@@ -5,7 +5,9 @@ import javax.validation.constraints.Size;
 
 import org.joda.time.DateTime;
 
-public class MaintenanceWindow
+import java.io.Serializable;
+
+public class MaintenanceWindow implements Serializable
 {
     @Size(max = 50)
     @NotNull
@@ -90,5 +92,8 @@ public class MaintenanceWindow
     {
         this.longMessage = longMessage;
     }
+
+
+    private static final long serialVersionUID = 1L;
 
 }

--- a/maintenance-filter-server/README.md
+++ b/maintenance-filter-server/README.md
@@ -34,7 +34,19 @@ Edit the target app's WEB-INF/web.xml file, and add configuration similar to the
     -->
   </context-param>
 
-  <!-- you need to set a shared secret to authenticate the maintenance-filter-controller client -->  
+  <!--
+    or, as a third alternative,
+    if you want to use an Infinispan cache to store the maintenance window data,
+    this parameter indicates where in JNDI the CacheContainer can be located.
+  -->
+  <context-param>
+    <param-name>org.ccci.maintenance.window.infinispan.cache.location</param-name>
+    <param-value>java:jboss/infinispan/container/maintenance-filter-windows</param-value>
+    <!-- or whatever jndi location you'd like -->
+  </context-param>
+
+
+  <!-- you need to set a shared secret to authenticate the maintenance-filter-controller client -->
   <context-param>
     <param-name>org.ccci.maintenance.window.key</param-name>
     <param-value>7xs2v4pjdve3rfx</param-value>

--- a/maintenance-filter-server/README.md
+++ b/maintenance-filter-server/README.md
@@ -9,7 +9,8 @@ copy jars into target app's WEB-INF/lib folder:
 * maintenance-filter-api-1-SNAPSHOT.jar
 * maintenance-filter-server-1-SNAPSHOT.jar
 
-(Note that versions are correct as of this writing, but may not be correct by the time you read this.)
+(Note that versions are correct as of this writing,
+but may not be correct by the time you read this.)
 
 Edit the target app's WEB-INF/web.xml file, and add configuration similar to the following:
  ```xml
@@ -61,7 +62,8 @@ Edit the target app's WEB-INF/web.xml file, and add configuration similar to the
       For example, here, any url starting with /ignored/ and
       any url ending with .jpg should not be blocked.
       These are regular expressions, not normal web.xml url mapping expressions.
-      Note that the control servlet's url does not need to be listed here; it will be bypassed automatically.
+      Note that the control servlet's url does not need to be listed here;
+      it will be bypassed automatically.
     -->
     <init-param>
       <param-name>bypassUrlPatterns</param-name>
@@ -82,11 +84,13 @@ Edit the target app's WEB-INF/web.xml file, and add configuration similar to the
 Usage on Tomcat
 ---------------
 
-If you configure the maintenance filter to set up its own maintenance database (eg by using
-`org.ccci.maintenance.window.db.path`), then be aware that you may see these log lines when you shut down tomcat:
+If you configure the maintenance filter to set up its own maintenance database
+(eg by using `org.ccci.maintenance.window.db.path`),
+then be aware that you may see these log lines when you shut down tomcat:
 ```
 SEVERE: The web application [/myapp] appears to have started a thread named [H2 Log Writer MAINTENANCE_FILTER] but has failed to stop it. This is very likely to create a memory leak.
 ```
-I believe this is due to the fact that H2 shuts down somewhat asynchronously, and its shutdown thread isn't finished by
-the time Tomcat checks for un-cleaned-up threads.  I am not sure if this causes a webapp-classloader leak or not, but I
-don't think it does.
+I believe this is due to the fact that H2 shuts down somewhat asynchronously,
+and its shutdown thread isn't finished by the time Tomcat checks for un-cleaned-up threads.
+I am not sure if this causes a webapp-classloader leak or not,
+but I don't think it does.

--- a/maintenance-filter-server/README.md
+++ b/maintenance-filter-server/README.md
@@ -3,7 +3,7 @@ Installation instructions
 
 
 copy jars into target app's WEB-INF/lib folder:
-* h2-1.2.142.jar
+* h2-1.2.142.jar (only if you are using org.ccci.maintenance.window.db.path below)
 * joda-time-1.6.jar
 * log4j-1.2.14.jar
 * maintenance-filter-api-1-SNAPSHOT.jar

--- a/maintenance-filter-server/README.md
+++ b/maintenance-filter-server/README.md
@@ -3,7 +3,6 @@ Installation instructions
 
 
 copy jars into target app's WEB-INF/lib folder:
-* guava-r07.jar
 * h2-1.2.142.jar
 * joda-time-1.6.jar
 * log4j-1.2.14.jar

--- a/maintenance-filter-server/pom.xml
+++ b/maintenance-filter-server/pom.xml
@@ -51,7 +51,19 @@
       <artifactId>commons-io</artifactId>
       <version>1.4</version>
     </dependency>
-    
+
+    <!--
+      for applications that wish to use Infinispan for storage
+    -->
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-core</artifactId>
+      <version>6.0.2.Final</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
+
     <!-- test libs -->
     
     <dependency>

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/Bootstrap.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/Bootstrap.java
@@ -3,6 +3,7 @@ package org.ccci.maintenance;
 import org.ccci.maintenance.util.Clock;
 import org.ccci.maintenance.util.ConfigReader;
 import org.ccci.maintenance.util.JdbcMaintenanceWindowDao;
+import org.ccci.maintenance.util.MaintenanceWindowDaoFactory;
 
 import javax.servlet.ServletContext;
 import javax.sql.DataSource;
@@ -12,13 +13,15 @@ public class Bootstrap
 
     private final ServletContext servletContext;
     private final ConfigReader configReader;
-    private DatasourceManager datasourceManager;
+    private MaintenanceWindowDaoFactory daoFactory;
 
     public Bootstrap(ServletContext servletContext)
     {
         this.servletContext = servletContext;
         this.configReader = new ConfigReader(servletContext, System.getProperties());
-        this.datasourceManager = new DatasourceManager(configReader);
+        this.daoFactory = new MaintenanceWindowDaoFactory(
+            configReader,
+            new DatasourceManager(configReader));
     }
 
     public static Bootstrap getInstance(ServletContext servletContext)
@@ -41,28 +44,34 @@ public class Bootstrap
         maintenanceService.addFilterName(filterName);
     }
 
-    private MaintenanceServiceImpl getOrCreateMaintenanceService()
+    private synchronized MaintenanceServiceImpl getOrCreateMaintenanceService()
     {
         String bootstrapLocation = Bootstrap.class.getName();
         Bootstrap bootstrap = (Bootstrap) servletContext.getAttribute(bootstrapLocation);
         MaintenanceServiceImpl maintenanceService;
         if (bootstrap == null)
         {
-            DataSource dataSource = datasourceManager.lookupOrCreateDataSource();
-            initDatabaseIfNecessary(dataSource);
-            servletContext.setAttribute(bootstrapLocation, this);
-
-            String key = getKey();
-            maintenanceService = new MaintenanceServiceImpl(
-                Clock.system(),
-                new JdbcMaintenanceWindowDao(dataSource),
-                key);
-            servletContext.setAttribute(getMaintenanceServiceLocation(), maintenanceService);
+            maintenanceService = storeThisBootstrapAndCreateMaintenanceService(bootstrapLocation);
         }
         else
         {
             maintenanceService = getMaintenanceServiceImpl();
         }
+        return maintenanceService;
+    }
+
+    private MaintenanceServiceImpl storeThisBootstrapAndCreateMaintenanceService(String
+        bootstrapLocation)
+    {
+        daoFactory.initialize();
+        servletContext.setAttribute(bootstrapLocation, this);
+
+        String key = getKey();
+        MaintenanceServiceImpl maintenanceService = new MaintenanceServiceImpl(
+            Clock.system(),
+            daoFactory.createDao(),
+            key);
+        servletContext.setAttribute(getMaintenanceServiceLocation(), maintenanceService);
         return maintenanceService;
     }
 
@@ -83,12 +92,7 @@ public class Bootstrap
     /** may be called multiple times, if multiple filters are configured */
     public void shutdown()
     {
-        datasourceManager.shutdownPoolIfNecessary();
-    }
-
-    private void initDatabaseIfNecessary(DataSource dataSource)
-    {
-        new DatabaseMigrator(dataSource).migrate();
+        daoFactory.shutdown();
     }
 
     public MaintenanceService getMaintenanceService()

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/Bootstrap.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/Bootstrap.java
@@ -30,7 +30,7 @@ public class Bootstrap
         }
         else
         {
-            throw new IllegalStateException("Boostrap has not yet been created");
+            throw new IllegalStateException("Bootstrap has not yet been created");
         }
     }
 

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/Bootstrap.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/Bootstrap.java
@@ -2,6 +2,7 @@ package org.ccci.maintenance;
 
 import org.ccci.maintenance.util.Clock;
 import org.ccci.maintenance.util.ConfigReader;
+import org.ccci.maintenance.util.JdbcMaintenanceWindowDao;
 
 import javax.servlet.ServletContext;
 import javax.sql.DataSource;
@@ -52,7 +53,10 @@ public class Bootstrap
             servletContext.setAttribute(bootstrapLocation, this);
 
             String key = getKey();
-            maintenanceService = new MaintenanceServiceImpl(Clock.system(), dataSource, key);
+            maintenanceService = new MaintenanceServiceImpl(
+                Clock.system(),
+                new JdbcMaintenanceWindowDao(dataSource),
+                key);
             servletContext.setAttribute(getMaintenanceServiceLocation(), maintenanceService);
         }
         else

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/DatasourceManager.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/DatasourceManager.java
@@ -2,6 +2,7 @@ package org.ccci.maintenance;
 
 import org.ccci.maintenance.util.ConfigReader;
 import org.ccci.maintenance.util.Exceptions;
+import org.ccci.maintenance.util.Lookups;
 
 import javax.naming.InitialContext;
 import javax.naming.NameNotFoundException;
@@ -34,7 +35,7 @@ public class DatasourceManager {
         String datasourceLocation = configReader.getParameter(datasourceParamName);
         if (datasourceLocation != null)
         {
-            return lookupDataSource(datasourceLocation);
+            return Lookups.doLookup(datasourceLocation, DataSource.class);
         }
         else
         {
@@ -125,34 +126,6 @@ public class DatasourceManager {
         catch (IOException e)
         {
             Exceptions.swallow(e, "exception closing config stream");
-        }
-    }
-
-    private DataSource lookupDataSource(String datasourceLocation)
-    {
-        try
-        {
-            Object found = new InitialContext().lookup(datasourceLocation);
-            if (found == null)
-            {
-                throw new IllegalStateException("No datasource bound at " + datasourceLocation);
-            }
-            if (!(found instanceof DataSource))
-            {
-                throw new IllegalStateException(String.format(
-                    "Found %s bound at %s instead of a DataSource",
-                    found,
-                    datasourceLocation));
-            }
-            return (DataSource) found;
-        }
-        catch (NameNotFoundException e)
-        {
-            throw new IllegalStateException("No datasource bound at " + datasourceLocation, e);
-        }
-        catch (NamingException e)
-        {
-            throw Exceptions.wrap(e);
         }
     }
 

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/MaintenanceServiceImpl.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/MaintenanceServiceImpl.java
@@ -64,12 +64,12 @@ public class MaintenanceServiceImpl implements MaintenanceService
 
     private void checkIdNotInUseByAnotherFilter(OwnedMaintenanceWindow existing, String id, String targetFilterName)
     {
-        String otherfilterName = existing.owner;
+        String otherFilterName = existing.owner;
         Preconditions.checkArgument(
-            Objects.equal(otherfilterName, targetFilterName),
+            Objects.equal(otherFilterName, targetFilterName),
             "the '%s' maintenance window is owned by %s, not by %s",
             id,
-            getFilterDescription(otherfilterName),
+            getFilterDescription(otherFilterName),
             getFilterDescription(targetFilterName));
     }
 

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/MaintenanceServiceImpl.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/MaintenanceServiceImpl.java
@@ -14,7 +14,9 @@ import javax.sql.DataSource;
 import org.ccci.maintenance.util.Clock;
 import org.ccci.maintenance.util.Exceptions;
 import org.ccci.maintenance.util.JdbcUtils;
+import org.ccci.maintenance.util.MaintenanceWindowDao;
 import org.ccci.maintenance.util.Objects;
+import org.ccci.maintenance.util.OwnedMaintenanceWindow;
 import org.ccci.maintenance.util.Preconditions;
 import org.ccci.maintenance.util.Strings;
 import org.ccci.maintenance.util.TimeUtil;
@@ -26,14 +28,14 @@ public class MaintenanceServiceImpl implements MaintenanceService
 {
     
     private final Clock clock;
-    private final DataSource dataSource;
+    private MaintenanceWindowDao dao;
     private String key;
     private Set<String> filterNames = new HashSet<String>(5);
 
-    public MaintenanceServiceImpl(Clock clock, DataSource dataSource, String key)
+    public MaintenanceServiceImpl(Clock clock, MaintenanceWindowDao dao, String key)
     {
         this.clock = clock;
-        this.dataSource = dataSource;
+        this.dao = dao;
         this.key = key;
     }
 
@@ -42,246 +44,39 @@ public class MaintenanceServiceImpl implements MaintenanceService
         if (!filterExists(filterName))
             throw new IllegalStateException("invalid filterName: " + filterName);
 
-        Connection connection;
-        try
-        {
-            connection = dataSource.getConnection();
-            try
-            {
-                return getCurrentWindowWithConnection(connection, filterName);
-            }
-            finally
-            {
-                JdbcUtils.close(connection);
-            }
-        }
-        catch (SQLException e)
-        {
-            throw Exceptions.wrap(e);
-        }
+        return dao.getActiveMaintenanceWindow(filterName, clock.currentDateTime());
     }
 
-    private MaintenanceWindow getCurrentWindowWithConnection(Connection connnection, String filterName) throws SQLException
-    {
-        String sql = "select * from MaintenanceWindow where " +
-        		"(beginAt < ? or beginAt is null) and " +
-        		"(endAt > ? or endAt is null) " + buildFilterNameClause(filterName);
-        PreparedStatement statement = connnection.prepareStatement(sql);
-        try
-        {
-            return getCurrentWindowWithStatement(statement, filterName);
-        }
-        finally
-        {
-            JdbcUtils.close(statement);
-        }
-    }
 
-    private String buildFilterNameClause(String filterName)
-    {
-        if (filterName == null)
-            return " and (filterName is null)";
-        else
-            return " and (filterName = ?)"; 
-    }
-
-    private MaintenanceWindow getCurrentWindowWithStatement(PreparedStatement statement, String filterName) throws SQLException
-    {
-        DateTime currentDateTime = clock.currentDateTime();
-        Timestamp timestamp = TimeUtil.dateTimeToSqlTimestamp(currentDateTime);
-        ResultSet resultSet;
-        statement.setTimestamp(1, timestamp);
-        statement.setTimestamp(2, timestamp);
-        if (filterName != null)
-        {
-            statement.setString(3, filterName);
-        }
-        resultSet = statement.executeQuery();
-        try
-        {
-            return getCurrentWindowWithResultSet(resultSet);
-        }
-        finally
-        {
-            JdbcUtils.close(resultSet);
-        }
-    }
-    
-    private MaintenanceWindow getCurrentWindowWithResultSet(ResultSet resultSet) throws SQLException
-    {
-        if (!resultSet.next())
-        {
-            return null;
-        }
-        MaintenanceWindow window = buildWindow(resultSet);
-        if (resultSet.next())
-        {
-            throw new IllegalStateException("More than one window are currently active!");
-        }
-        return window;
-    }
-
-    private MaintenanceWindow buildWindow(ResultSet resultSet) throws SQLException
-    {
-        MaintenanceWindow window = new MaintenanceWindow();
-        window.setId(resultSet.getString("id"));
-        window.setShortMessage(resultSet.getString("shortMessage"));
-        window.setLongMessage(resultSet.getString("longMessage"));
-        window.setBeginAt(TimeUtil.sqlTimestampToDateTime(resultSet.getTimestamp("beginAt")));
-        window.setEndAt(TimeUtil.sqlTimestampToDateTime(resultSet.getTimestamp("endAt")));
-        return window;
-    }
-    
     public void createOrUpdateMaintenanceWindow(String filterName, MaintenanceWindow window)
     {
-        Connection connection;
-        try
+        OwnedMaintenanceWindow existingWindow = dao.getMaintenanceWindowById(window.getId());
+        if (existingWindow == null)
         {
-            connection = dataSource.getConnection();
-            try
-            {
-                createOrUpdateMaintenanceWindowWithConnection(connection, window, filterName);
-            }
-            finally
-            {
-                JdbcUtils.close(connection);
-            }
+            dao.createMaintenanceWindow(new OwnedMaintenanceWindow(window, filterName));
         }
-        catch (SQLException e)
+        else
         {
-            throw Exceptions.wrap(e);
+            checkIdNotInUseByAnotherFilter(existingWindow, window.getId(), filterName);
+            dao.updateMaintenanceWindow(new OwnedMaintenanceWindow(window, filterName));
         }
     }
 
-    private void createOrUpdateMaintenanceWindowWithConnection(Connection connnection, MaintenanceWindow window, String filterName) throws SQLException
+    private void checkIdNotInUseByAnotherFilter(OwnedMaintenanceWindow existing, String id, String targetFilterName)
     {
-        /* don't really need to deal with transactions here; we're simple enough to get by with autocommit */
-        connnection.setAutoCommit(true);
-        
-        if (! updateMaintenanceWindowWithConnection(connnection, window, filterName))
-        {
-            createMaintenanceWindowWithConnection(connnection, window, filterName);
-        }
+        String otherfilterName = existing.owner;
+        Preconditions.checkArgument(
+            Objects.equal(otherfilterName, targetFilterName),
+            "the '%s' maintenance window is owned by %s, not by %s",
+            id,
+            getFilterDescription(otherfilterName),
+            getFilterDescription(targetFilterName));
     }
 
-    /** returns true if the row existed and was updated, false otherwise */
-    private boolean updateMaintenanceWindowWithConnection(Connection connection, MaintenanceWindow window, String filterName) throws SQLException
-    {
-        checkIdNotInUseByAnotherFilter(connection, window.getId(), filterName);
-        
-        String sql = "update MaintenanceWindow " +
-        		"set " +
-        		"shortMessage = ?, " +
-        		"longMessage = ?, " +
-        		"beginAt = ?, " +
-        		"endAt = ? " +
-                "where id = ?";
-        PreparedStatement statement = connection.prepareStatement(sql);
-        try
-        {
-            return updateMaintenanceWindowWithStatement(statement, window);
-        }
-        finally
-        {
-            JdbcUtils.close(statement);
-        }
-    }
-
-    private void checkIdNotInUseByAnotherFilter(Connection connection, String id, String filterName) throws SQLException
-    {
-        String sql = "select filterName from MaintenanceWindow where id = ?";
-        PreparedStatement statement = connection.prepareStatement(sql);
-        try
-        {
-            checkIdNotInUseByAnotherFilterWithStatement(statement, id, filterName);
-        }
-        finally
-        {
-            JdbcUtils.close(statement);
-        }
-    }
-
-    private void checkIdNotInUseByAnotherFilterWithStatement(PreparedStatement statement, String id, String filterName) throws SQLException
-    {
-        statement.setString(1, id);
-        ResultSet resultSet = statement.executeQuery();
-        try
-        {
-            checkIdNotInUseByAnotherFilterWithResultSet(resultSet, id, filterName);
-        }
-        finally
-        {
-            JdbcUtils.close(resultSet);
-        }
-    }
-
-    private void checkIdNotInUseByAnotherFilterWithResultSet(ResultSet resultSet, String id, String targetFilterName) throws SQLException
-    {
-        if (resultSet.next())
-        {
-            String otherfilterName = resultSet.getString("filterName");
-            Preconditions.checkArgument(Objects.equal(otherfilterName, targetFilterName),
-                "the '%s' maintenance window is owned by %s, not by %s",
-                id,
-                getFilterDescription(otherfilterName),
-                getFilterDescription(targetFilterName));
-            Preconditions.checkState(!resultSet.next(), "More than one window exists for id " + id);
-        }
-    }
 
     private String getFilterDescription(String filterName)
     {
         return filterName == null ? "the default filter" : "the " + filterName + " filter";
-    }
-
-    private boolean updateMaintenanceWindowWithStatement(PreparedStatement statement, MaintenanceWindow window) throws SQLException
-    {
-        statement.setString(1, window.getShortMessage());
-        statement.setString(2, window.getLongMessage());
-        statement.setTimestamp(3, TimeUtil.dateTimeToSqlTimestamp(window.getBeginAt()));
-        statement.setTimestamp(4, TimeUtil.dateTimeToSqlTimestamp(window.getEndAt()));
-        statement.setString(5, window.getId());
-        int rowsUpdated = statement.executeUpdate();
-        if (rowsUpdated > 1)
-            throw new IllegalStateException("More than one row updated by update call for id: " + window.getId());
-        assert rowsUpdated >= 0;
-        return rowsUpdated == 1;
-    }
-    
-    private void createMaintenanceWindowWithConnection(Connection connnection, MaintenanceWindow window, String filterName) throws SQLException
-    {
-        String sql = "insert into MaintenanceWindow (" +
-                "shortMessage, " +
-                "longMessage, " +
-                "beginAt, " +
-                "endAt, " +
-                "id, " +
-                "filterName" +
-                ") values (" +
-                "?, ?, ?, ?, ?, ?" +
-                ")";
-        PreparedStatement statement = connnection.prepareStatement(sql);
-        try
-        {
-            createMaintenanceWindowWithStatement(statement, window, filterName);
-        }
-        finally
-        {
-            JdbcUtils.close(statement);
-        }
-    }
-
-    private void createMaintenanceWindowWithStatement(PreparedStatement statement, MaintenanceWindow window, String filterName) throws SQLException
-    {
-        statement.setString(1, window.getShortMessage());
-        statement.setString(2, window.getLongMessage());
-        statement.setTimestamp(3, TimeUtil.dateTimeToSqlTimestamp(window.getBeginAt()));
-        statement.setTimestamp(4, TimeUtil.dateTimeToSqlTimestamp(window.getEndAt()));
-        statement.setString(5, window.getId());
-        statement.setString(6, filterName);
-        int rowsUpdated = statement.executeUpdate();
-        if (rowsUpdated != 1)
-            throw new IllegalStateException("Exactly one row was not inserted, as expected; row count: " + rowsUpdated + ", id: " + window.getId());
     }
 
     public boolean isAuthenticated(String key) {

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/MaintenanceServiceImpl.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/MaintenanceServiceImpl.java
@@ -108,4 +108,10 @@ public class MaintenanceServiceImpl implements MaintenanceService
         //If/when I depend on guava, use ImmutableSet instead
         filterNames = Collections.unmodifiableSet(filterNames);
     }
+
+    @Override
+    public String toString()
+    {
+        return "MaintenanceServiceImpl[dao=" + dao.getClass().getSimpleName() +"]";
+    }
 }

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/InfinispanMaintenanceWindowDao.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/InfinispanMaintenanceWindowDao.java
@@ -2,6 +2,7 @@ package org.ccci.maintenance.util;
 
 import org.ccci.maintenance.MaintenanceWindow;
 import org.infinispan.Cache;
+import org.infinispan.manager.CacheContainer;
 import org.joda.time.DateTime;
 
 import java.util.Map;
@@ -16,9 +17,10 @@ public class InfinispanMaintenanceWindowDao implements MaintenanceWindowDao
 
     //using Object instead of Cache here to allow caller to avoid a hard dependency upon infinispan
     @SuppressWarnings("unchecked")
-    public InfinispanMaintenanceWindowDao(Object cache)
+    public InfinispanMaintenanceWindowDao(Object containerAsObject)
     {
-        this.cache = (Cache<String, OwnedMaintenanceWindow>) cache;
+        CacheContainer cacheContainer = (CacheContainer) containerAsObject;
+        cache = cacheContainer.getCache();
     }
 
     public MaintenanceWindow getActiveMaintenanceWindow(

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/InfinispanMaintenanceWindowDao.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/InfinispanMaintenanceWindowDao.java
@@ -1,0 +1,82 @@
+package org.ccci.maintenance.util;
+
+import org.ccci.maintenance.MaintenanceWindow;
+import org.infinispan.Cache;
+import org.joda.time.DateTime;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Matt Drees
+ */
+public class InfinispanMaintenanceWindowDao implements MaintenanceWindowDao
+{
+    private final Cache<String, OwnedMaintenanceWindow> cache;
+
+    //using Object instead of Cache here to allow caller to avoid a hard dependency upon infinispan
+    @SuppressWarnings("unchecked")
+    public InfinispanMaintenanceWindowDao(Object cache)
+    {
+        this.cache = (Cache<String, OwnedMaintenanceWindow>) cache;
+    }
+
+    public MaintenanceWindow getActiveMaintenanceWindow(
+        String filterName, DateTime currentDateTime)
+    {
+        for (Map.Entry<String, OwnedMaintenanceWindow> entry : cache.entrySet())
+        {
+            if (windowIsActiveAndOwnedByFilter(filterName, currentDateTime, entry))
+            {
+                return entry.getValue().window;
+            }
+        }
+
+        return null;
+    }
+
+    private boolean windowIsActiveAndOwnedByFilter(
+        String filterName,
+        DateTime currentDateTime,
+        Map.Entry<String, OwnedMaintenanceWindow> entry)
+    {
+        MaintenanceWindow window = entry.getValue().window;
+        String owner = entry.getValue().owner;
+
+        return windowHasBegun(currentDateTime, window.getBeginAt()) &&
+            windowHasNotYetEnded(currentDateTime, window.getEndAt()) &&
+            Objects.equal(owner, filterName);
+    }
+
+    private boolean windowHasBegun(
+        DateTime currentDateTime, DateTime beginAt)
+    {
+        return beginAt == null || beginAt.isBefore(currentDateTime);
+    }
+
+    private boolean windowHasNotYetEnded(
+        DateTime currentDateTime, DateTime endAt)
+    {
+        return endAt == null || endAt.isAfter(currentDateTime);
+    }
+
+    public OwnedMaintenanceWindow getMaintenanceWindowById(String id)
+    {
+        return cache.get(id);
+    }
+
+    public void createMaintenanceWindow(OwnedMaintenanceWindow ownedMaintenanceWindow)
+    {
+        putOrReplace(ownedMaintenanceWindow);
+    }
+
+    private void putOrReplace(OwnedMaintenanceWindow ownedMaintenanceWindow)
+    {
+        cache.put(ownedMaintenanceWindow.window.getId(), ownedMaintenanceWindow);
+    }
+
+    public void updateMaintenanceWindow(OwnedMaintenanceWindow ownedMaintenanceWindow)
+    {
+        putOrReplace(ownedMaintenanceWindow);
+    }
+}

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/JdbcMaintenanceWindowDao.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/JdbcMaintenanceWindowDao.java
@@ -46,14 +46,14 @@ public class JdbcMaintenanceWindowDao implements MaintenanceWindowDao
     }
 
     private MaintenanceWindow getCurrentWindowWithConnection(
-        Connection connnection,
+        Connection connection,
         String filterName,
         DateTime currentDateTime) throws SQLException
     {
         String sql = "select * from MaintenanceWindow where " +
                      "(beginAt < ? or beginAt is null) and " +
                      "(endAt > ? or endAt is null) " + buildFilterNameClause(filterName);
-        PreparedStatement statement = connnection.prepareStatement(sql);
+        PreparedStatement statement = connection.prepareStatement(sql);
         try
         {
             return getCurrentWindowWithStatement(statement, filterName, currentDateTime);

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/JdbcMaintenanceWindowDao.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/JdbcMaintenanceWindowDao.java
@@ -1,0 +1,332 @@
+package org.ccci.maintenance.util;
+
+import org.ccci.maintenance.MaintenanceWindow;
+import org.joda.time.DateTime;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+
+/**
+ * @author Matt Drees
+ */
+public class JdbcMaintenanceWindowDao implements MaintenanceWindowDao
+{
+    private final DataSource dataSource;
+
+    public JdbcMaintenanceWindowDao(DataSource dataSource)
+    {
+        this.dataSource = dataSource;
+    }
+
+    public MaintenanceWindow getActiveMaintenanceWindow(
+        String filterName,
+        DateTime currentDateTime)
+    {
+        Connection connection;
+        try
+        {
+            connection = dataSource.getConnection();
+            try
+            {
+                return getCurrentWindowWithConnection(connection, filterName, currentDateTime);
+            }
+            finally
+            {
+                JdbcUtils.close(connection);
+            }
+        }
+        catch (SQLException e)
+        {
+            throw Exceptions.wrap(e);
+        }
+    }
+
+    private MaintenanceWindow getCurrentWindowWithConnection(
+        Connection connnection,
+        String filterName,
+        DateTime currentDateTime) throws SQLException
+    {
+        String sql = "select * from MaintenanceWindow where " +
+                     "(beginAt < ? or beginAt is null) and " +
+                     "(endAt > ? or endAt is null) " + buildFilterNameClause(filterName);
+        PreparedStatement statement = connnection.prepareStatement(sql);
+        try
+        {
+            return getCurrentWindowWithStatement(statement, filterName, currentDateTime);
+        }
+        finally
+        {
+            JdbcUtils.close(statement);
+        }
+    }
+
+    private String buildFilterNameClause(String filterName)
+    {
+        if (filterName == null)
+            return " and (filterName is null)";
+        else
+            return " and (filterName = ?)";
+    }
+
+    private MaintenanceWindow getCurrentWindowWithStatement(
+        PreparedStatement statement,
+        String filterName, DateTime currentDateTime) throws SQLException
+    {
+        Timestamp timestamp = TimeUtil.dateTimeToSqlTimestamp(currentDateTime);
+        ResultSet resultSet;
+        statement.setTimestamp(1, timestamp);
+        statement.setTimestamp(2, timestamp);
+        if (filterName != null)
+        {
+            statement.setString(3, filterName);
+        }
+        resultSet = statement.executeQuery();
+        try
+        {
+            return getCurrentWindowWithResultSet(resultSet);
+        }
+        finally
+        {
+            JdbcUtils.close(resultSet);
+        }
+    }
+
+    private MaintenanceWindow getCurrentWindowWithResultSet(ResultSet resultSet) throws SQLException
+    {
+        if (!resultSet.next())
+        {
+            return null;
+        }
+        MaintenanceWindow window = buildWindow(resultSet);
+        if (resultSet.next())
+        {
+            throw new IllegalStateException("More than one window are currently active!");
+        }
+        return window;
+    }
+
+    private MaintenanceWindow buildWindow(ResultSet resultSet) throws SQLException
+    {
+        MaintenanceWindow window = new MaintenanceWindow();
+        window.setId(resultSet.getString("id"));
+        window.setShortMessage(resultSet.getString("shortMessage"));
+        window.setLongMessage(resultSet.getString("longMessage"));
+        window.setBeginAt(TimeUtil.sqlTimestampToDateTime(resultSet.getTimestamp("beginAt")));
+        window.setEndAt(TimeUtil.sqlTimestampToDateTime(resultSet.getTimestamp("endAt")));
+        return window;
+    }
+
+    public OwnedMaintenanceWindow getMaintenanceWindowById(String id)
+    {
+
+        Connection connection;
+        try
+        {
+            connection = dataSource.getConnection();
+            try
+            {
+                return getMaintenanceWindowByIdWithConnection(id, connection);
+            }
+            finally
+            {
+                JdbcUtils.close(connection);
+            }
+        }
+        catch (SQLException e)
+        {
+            throw Exceptions.wrap(e);
+        }
+
+    }
+
+    private OwnedMaintenanceWindow getMaintenanceWindowByIdWithConnection(
+        String id,
+        Connection connection)
+        throws SQLException
+    {
+        String sql = "select * from MaintenanceWindow where id = ?";
+        PreparedStatement statement = connection.prepareStatement(sql);
+        try
+        {
+            return getMaintenanceWindowByIdWithStatement(statement, id);
+        }
+        finally
+        {
+            JdbcUtils.close(statement);
+        }
+    }
+
+    private OwnedMaintenanceWindow getMaintenanceWindowByIdWithStatement(
+        PreparedStatement statement,
+        String id) throws SQLException
+    {
+        statement.setString(1, id);
+        ResultSet resultSet = statement.executeQuery();
+        try
+        {
+            if (!resultSet.next())
+            {
+                return null;
+            }
+            else
+            {
+                MaintenanceWindow window = buildWindow(resultSet);
+                String owner = resultSet.getString("filterName");
+                OwnedMaintenanceWindow ownedMaintenanceWindow =
+                    new OwnedMaintenanceWindow(window, owner);
+
+                Preconditions.checkState(
+                    !resultSet.next(),
+                    "More than one window exists for id " + id);
+                return ownedMaintenanceWindow;
+            }
+        }
+        finally
+        {
+            JdbcUtils.close(resultSet);
+        }
+    }
+
+
+    public void createMaintenanceWindow(OwnedMaintenanceWindow window)
+    {
+        Connection connection;
+        try
+        {
+            connection = connectAndSetAutoCommit();
+
+            try
+            {
+                createMaintenanceWindowWithConnection(connection, window);
+            }
+            finally
+            {
+                JdbcUtils.close(connection);
+            }
+        }
+        catch (SQLException e)
+        {
+            throw Exceptions.wrap(e);
+        }
+    }
+
+    private void createMaintenanceWindowWithConnection(
+        Connection connection,
+        OwnedMaintenanceWindow window) throws SQLException
+    {
+        String sql = "insert into MaintenanceWindow (" +
+                     "shortMessage, " +
+                     "longMessage, " +
+                     "beginAt, " +
+                     "endAt, " +
+                     "id, " +
+                     "filterName" +
+                     ") values (" +
+                     "?, ?, ?, ?, ?, ?" +
+                     ")";
+        PreparedStatement statement = connection.prepareStatement(sql);
+        try
+        {
+            createMaintenanceWindowWithStatement(statement, window);
+        }
+        finally
+        {
+            JdbcUtils.close(statement);
+        }
+    }
+
+    private void createMaintenanceWindowWithStatement(
+        PreparedStatement statement,
+        OwnedMaintenanceWindow ownedMaintenanceWindow) throws SQLException
+    {
+        String filterName = ownedMaintenanceWindow.owner;
+        MaintenanceWindow window = ownedMaintenanceWindow.window;
+        statement.setString(1, window.getShortMessage());
+        statement.setString(2, window.getLongMessage());
+        statement.setTimestamp(3, TimeUtil.dateTimeToSqlTimestamp(window.getBeginAt()));
+        statement.setTimestamp(4, TimeUtil.dateTimeToSqlTimestamp(window.getEndAt()));
+        statement.setString(5, window.getId());
+        statement.setString(6, filterName);
+        int rowsUpdated = statement.executeUpdate();
+        if (rowsUpdated != 1)
+            throw new IllegalStateException("Exactly one row was not inserted, as expected; row count: " + rowsUpdated + ", id: " + window.getId());
+    }
+
+    private Connection connectAndSetAutoCommit() throws SQLException
+    {
+        Connection connection = dataSource.getConnection();
+
+        /* don't really need to deal with transactions here;
+         * we're simple enough to get by with autocommit
+         */
+        connection.setAutoCommit(true);
+        return connection;
+    }
+
+    public void updateMaintenanceWindow(OwnedMaintenanceWindow window)
+    {
+        Connection connection;
+        try
+        {
+            connection = connectAndSetAutoCommit();
+            try
+            {
+                updateMaintenanceWindowWithConnection(connection, window);
+            }
+            finally
+            {
+                JdbcUtils.close(connection);
+            }
+        }
+        catch (SQLException e)
+        {
+            throw Exceptions.wrap(e);
+        }
+
+    }
+
+    private void updateMaintenanceWindowWithConnection(
+        Connection connection,
+        OwnedMaintenanceWindow window) throws SQLException
+    {
+
+        String sql = "update MaintenanceWindow " +
+                     "set " +
+                     "shortMessage = ?, " +
+                     "longMessage = ?, " +
+                     "beginAt = ?, " +
+                     "endAt = ? " +
+                     "where id = ?";
+        PreparedStatement statement = connection.prepareStatement(sql);
+        try
+        {
+            updateMaintenanceWindowWithStatement(statement, window);
+        }
+        finally
+        {
+            JdbcUtils.close(statement);
+        }
+    }
+
+    private boolean updateMaintenanceWindowWithStatement(
+        PreparedStatement statement,
+        OwnedMaintenanceWindow ownedMaintenanceWindow) throws SQLException
+    {
+        MaintenanceWindow window = ownedMaintenanceWindow.window;
+        statement.setString(1, window.getShortMessage());
+        statement.setString(2, window.getLongMessage());
+        statement.setTimestamp(3, TimeUtil.dateTimeToSqlTimestamp(window.getBeginAt()));
+        statement.setTimestamp(4, TimeUtil.dateTimeToSqlTimestamp(window.getEndAt()));
+        statement.setString(5, window.getId());
+        int rowsUpdated = statement.executeUpdate();
+        if (rowsUpdated > 1)
+            throw new IllegalStateException("More than one row updated by update call for id: " + window.getId());
+        assert rowsUpdated >= 0;
+        return rowsUpdated == 1;
+    }
+
+}

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/Lookups.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/Lookups.java
@@ -1,0 +1,49 @@
+package org.ccci.maintenance.util;
+
+import javax.naming.InitialContext;
+import javax.naming.NameNotFoundException;
+import javax.naming.NamingException;
+
+/**
+ * @author Matt Drees
+ */
+public class Lookups
+{
+    public static <T> T doLookup(String location, Class<T> expectedType)
+    {
+        try
+        {
+            Object found = new InitialContext().lookup(location);
+            if (found == null)
+            {
+                throw notFound(location, expectedType);
+            }
+            if (!expectedType.isInstance(found))
+            {
+                throw new IllegalStateException(String.format(
+                    "Found %s bound at %s instead of a %s",
+                    found,
+                    location,
+                    expectedType.getSimpleName()));
+            }
+            return expectedType.cast(found);
+        }
+        catch (NameNotFoundException e)
+        {
+            throw notFound(location, expectedType);
+        }
+        catch (NamingException e)
+        {
+            throw Exceptions.wrap(e);
+        }
+    }
+
+    private static <T> IllegalStateException notFound(String location, Class<T> expectedType)
+    {
+        return new IllegalStateException(String.format(
+            "No %s bound at %s",
+            expectedType.getSimpleName(),
+            location));
+    }
+
+}

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/MaintenanceWindowDao.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/MaintenanceWindowDao.java
@@ -1,0 +1,16 @@
+package org.ccci.maintenance.util;
+
+import org.ccci.maintenance.MaintenanceWindow;
+import org.joda.time.DateTime;
+
+/**
+ * @author Matt Drees
+ */
+public interface MaintenanceWindowDao
+{
+    MaintenanceWindow getActiveMaintenanceWindow(String filterName, DateTime currentDateTime);
+    OwnedMaintenanceWindow getMaintenanceWindowById(String id);
+
+    void createMaintenanceWindow(OwnedMaintenanceWindow window);
+    void updateMaintenanceWindow(OwnedMaintenanceWindow window);
+}

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/MaintenanceWindowDao.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/MaintenanceWindowDao.java
@@ -9,6 +9,8 @@ import org.joda.time.DateTime;
 public interface MaintenanceWindowDao
 {
     MaintenanceWindow getActiveMaintenanceWindow(String filterName, DateTime currentDateTime);
+
+    /** retrieves the window identified by the given id, or null if it does not exist */
     OwnedMaintenanceWindow getMaintenanceWindowById(String id);
 
     void createMaintenanceWindow(OwnedMaintenanceWindow window);

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/MaintenanceWindowDaoFactory.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/MaintenanceWindowDaoFactory.java
@@ -11,7 +11,8 @@ import javax.sql.DataSource;
 public class MaintenanceWindowDaoFactory
 {
 
-    String infinispanLocationParamName = "org.ccci.maintenance.window.infinispan.cache.location";
+    private static final String INFINISPAN_LOCATION_PARAM_NAME =
+        "org.ccci.maintenance.window.infinispan.cache.location";
 
     private final ConfigReader configReader;
     private DatasourceManager datasourceManager;
@@ -28,7 +29,7 @@ public class MaintenanceWindowDaoFactory
 
     public void initialize()
     {
-        String location = configReader.getParameter(infinispanLocationParamName);
+        String location = configReader.getParameter(INFINISPAN_LOCATION_PARAM_NAME);
         if (location == null)
         {
             dataSource = datasourceManager.lookupOrCreateDataSource();

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/MaintenanceWindowDaoFactory.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/MaintenanceWindowDaoFactory.java
@@ -16,7 +16,7 @@ public class MaintenanceWindowDaoFactory
     private final ConfigReader configReader;
     private DatasourceManager datasourceManager;
     private DataSource dataSource;
-    private Object cache;
+    private Object cacheContainer;
 
     public MaintenanceWindowDaoFactory(
         ConfigReader configReader,
@@ -37,23 +37,21 @@ public class MaintenanceWindowDaoFactory
         else
         {
             //avoid a hard dependency on infinispan, by not using Cache.class
-            Class<?> cacheClass = getInfinispanCacheClass();
-            cache = Lookups.doLookup(location, cacheClass);
+            Class<?> cacheContainerClass = getInfinispanCacheContainerClass();
+            cacheContainer = Lookups.doLookup(location, cacheContainerClass);
         }
     }
 
-    private Class<?> getInfinispanCacheClass()
+    private Class<?> getInfinispanCacheContainerClass()
     {
-        Class<?> cacheClass;
         try
         {
-            cacheClass = Class.forName("org.infinispan.Cache");
+            return Class.forName("org.infinispan.manager.CacheContainer");
         }
         catch (ClassNotFoundException e)
         {
             throw Exceptions.wrap(e);
         }
-        return cacheClass;
     }
 
     private void initDatabaseIfNecessary(DataSource dataSource)
@@ -75,7 +73,7 @@ public class MaintenanceWindowDaoFactory
         }
         else
         {
-            return new InfinispanMaintenanceWindowDao(cache);
+            return new InfinispanMaintenanceWindowDao(cacheContainer);
         }
     }
 }

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/MaintenanceWindowDaoFactory.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/MaintenanceWindowDaoFactory.java
@@ -37,7 +37,7 @@ public class MaintenanceWindowDaoFactory
         }
         else
         {
-            //avoid a hard dependency on infinispan, by not using Cache.class
+            //avoid a hard dependency on infinispan, by not using CacheContainer.class
             Class<?> cacheContainerClass = getInfinispanCacheContainerClass();
             cacheContainer = Lookups.doLookup(location, cacheContainerClass);
         }

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/MaintenanceWindowDaoFactory.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/MaintenanceWindowDaoFactory.java
@@ -1,0 +1,47 @@
+package org.ccci.maintenance.util;
+
+import org.ccci.maintenance.DatabaseMigrator;
+import org.ccci.maintenance.DatasourceManager;
+
+import javax.sql.DataSource;
+
+/**
+ * @author Matt Drees
+ */
+public class MaintenanceWindowDaoFactory
+{
+
+    private final ConfigReader configReader;
+    private DatasourceManager datasourceManager;
+    private DataSource dataSource;
+
+    public MaintenanceWindowDaoFactory(
+        ConfigReader configReader,
+        DatasourceManager datasourceManager)
+    {
+        this.configReader = configReader;
+        this.datasourceManager = datasourceManager;
+    }
+
+    public void initialize()
+    {
+        dataSource = datasourceManager.lookupOrCreateDataSource();
+        initDatabaseIfNecessary(dataSource);
+    }
+
+    private void initDatabaseIfNecessary(DataSource dataSource)
+    {
+        new DatabaseMigrator(dataSource).migrate();
+    }
+
+
+    public void shutdown()
+    {
+        datasourceManager.shutdownPoolIfNecessary();
+    }
+
+    public MaintenanceWindowDao createDao()
+    {
+        return new JdbcMaintenanceWindowDao(dataSource);
+    }
+}

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/OwnedMaintenanceWindow.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/OwnedMaintenanceWindow.java
@@ -1,0 +1,18 @@
+package org.ccci.maintenance.util;
+
+import org.ccci.maintenance.MaintenanceWindow;
+
+/**
+ * @author Matt Drees
+ */
+public class OwnedMaintenanceWindow
+{
+    public final MaintenanceWindow window;
+    public final String owner;
+
+    public OwnedMaintenanceWindow(MaintenanceWindow window, String owner)
+    {
+        this.window = window;
+        this.owner = owner;
+    }
+}

--- a/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/OwnedMaintenanceWindow.java
+++ b/maintenance-filter-server/src/main/java/org/ccci/maintenance/util/OwnedMaintenanceWindow.java
@@ -2,11 +2,15 @@ package org.ccci.maintenance.util;
 
 import org.ccci.maintenance.MaintenanceWindow;
 
+import java.io.Serializable;
+
 /**
  * @author Matt Drees
  */
-public class OwnedMaintenanceWindow
+public class OwnedMaintenanceWindow implements Serializable
 {
+    private static final long serialVersionUID = 1L;
+
     public final MaintenanceWindow window;
     public final String owner;
 

--- a/maintenance-filter-server/src/test/java/org/ccci/maintenance/MaintenanceServiceImplTest.java
+++ b/maintenance-filter-server/src/test/java/org/ccci/maintenance/MaintenanceServiceImplTest.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import javax.sql.DataSource;
 
 import org.ccci.maintenance.util.Clock;
+import org.ccci.maintenance.util.JdbcMaintenanceWindowDao;
 import org.h2.jdbcx.JdbcDataSource;
 import org.joda.time.DateTime;
 import org.mockito.Mock;
@@ -47,7 +48,7 @@ public class MaintenanceServiceImplTest
     @BeforeMethod
     public void setupService() throws SQLException
     {
-        service = new MaintenanceServiceImpl(clock, dataSource, "secrets");
+        service = new MaintenanceServiceImpl(clock, new JdbcMaintenanceWindowDao(dataSource), "secrets");
         service.addFilterName(null);
         service.addFilterName("special");
         service.initializationComplete();

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
+          <version>2.3</version>
           <executions>
             <execution>
               <id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,13 @@
         </plugin>
       </plugins>
     </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+
+    </plugins>
   </build>
 
   <licenses>


### PR DESCRIPTION
This pull request makes it possible to use the maintenance filter in a docker app running in an AWS ECS cluster.

Beforehand, an on-filesystem database was required to store the maintenance window information. However, for this to work with a dockerized app, the h2 file has to be located on a docker Volume. This is difficult to configure correctly in an aws ecs cluster.

So, we instead change strategies and store the windows in a single distributed cache (infinispan). This involves a little bit more 'moving parts' than the on-disk h2 system, so it is not as failure-tolerant, but I think it's a tradeoff we can live with.

Another key benefit is that by using a single window store, the client can send a single window update request to the loadbalancer instead of having to send several requests to each app instance directly, as was required before. This is handy because the hostnames of the app instances are not predictable ahead of time.
