### PR TITLE
Upgrade apache http client to 4.5.8

### DIFF
--- a/maintenance-filter-api/pom.xml
+++ b/maintenance-filter-api/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <artifactId>maintenance-filter</artifactId>
     <groupId>org.ccci</groupId>
-    <version>1-SNAPSHOT</version>
+    <version>1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>maintenance-filter-api</artifactId>

--- a/maintenance-filter-api/pom.xml
+++ b/maintenance-filter-api/pom.xml
@@ -6,8 +6,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>maintenance-filter-api</artifactId>
-  <version>1-SNAPSHOT</version>
-  
+
   <dependencies>
   
     <dependency>

--- a/maintenance-filter-controller/pom.xml
+++ b/maintenance-filter-controller/pom.xml
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.0</version>
+      <version>4.5.8</version>
     </dependency>
   
     <dependency>

--- a/maintenance-filter-controller/pom.xml
+++ b/maintenance-filter-controller/pom.xml
@@ -6,8 +6,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>maintenance-filter-controller</artifactId>
-  <version>1-SNAPSHOT</version>
-  
+
   <dependencies>
   
     <dependency>
@@ -31,7 +30,7 @@
     <dependency>
     	<groupId>org.ccci</groupId>
     	<artifactId>maintenance-filter-api</artifactId>
-    	<version>1-SNAPSHOT</version>
+    	<version>${project.version}</version>
     </dependency>
     
     <dependency>

--- a/maintenance-filter-controller/pom.xml
+++ b/maintenance-filter-controller/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <artifactId>maintenance-filter</artifactId>
     <groupId>org.ccci</groupId>
-    <version>1-SNAPSHOT</version>
+    <version>1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>maintenance-filter-controller</artifactId>

--- a/maintenance-filter-server/pom.xml
+++ b/maintenance-filter-server/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <artifactId>maintenance-filter</artifactId>
     <groupId>org.ccci</groupId>
-    <version>1-SNAPSHOT</version>
+    <version>1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>maintenance-filter-server</artifactId>

--- a/maintenance-filter-server/pom.xml
+++ b/maintenance-filter-server/pom.xml
@@ -6,8 +6,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>maintenance-filter-server</artifactId>
-  <version>1-SNAPSHOT</version>
-  
+
   <dependencies>
     <!--  provided by servlet container, or else not needed at runtime -->
     <dependency>
@@ -110,7 +109,7 @@
     <dependency>
     	<groupId>org.ccci</groupId>
     	<artifactId>maintenance-filter-api</artifactId>
-    	<version>1-SNAPSHOT</version>
+    	<version>${project.version}</version>
     </dependency>
     
     

--- a/maintenance-filter-test-webapp/pom.xml
+++ b/maintenance-filter-test-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>maintenance-filter</artifactId>
     <groupId>org.ccci</groupId>
-    <version>1-SNAPSHOT</version>
+    <version>1</version>
   </parent>
   <artifactId>maintenance-filter-test-webapp</artifactId>
   <packaging>war</packaging>

--- a/maintenance-filter-test-webapp/pom.xml
+++ b/maintenance-filter-test-webapp/pom.xml
@@ -39,6 +39,12 @@
       <artifactId>log4j</artifactId>
       <version>1.2.14</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>1.2.142</version>
+    </dependency>
     
   </dependencies>
   <build>

--- a/maintenance-filter-test-webapp/pom.xml
+++ b/maintenance-filter-test-webapp/pom.xml
@@ -8,7 +8,6 @@
   </parent>
   <artifactId>maintenance-filter-test-webapp</artifactId>
   <packaging>war</packaging>
-  <version>1-SNAPSHOT</version>
   <name>maintenance-filter-test-webapp JEE5 Webapp</name>
 
   <dependencies>
@@ -31,7 +30,7 @@
     <dependency>
       <groupId>org.ccci</groupId>
       <artifactId>maintenance-filter-server</artifactId>
-      <version>1-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>maintenance-filter</artifactId>
   <packaging>pom</packaging>
   <name>Maintenance Filter</name>
-  <version>1-SNAPSHOT</version>
+  <version>1</version>
   
   
   <description>Provides a utility to easily block access to a web application during a maintenance outage.  Users will see a configured message.</description>


### PR DESCRIPTION
This is primarily to address CVE-2012-6153, but also CVE-2015-5262.

It also releases a non-snapshot version, which hasn't been done before.
(I used to believe in using snapshots all the time, for internal libraries, but I don't anymore.)